### PR TITLE
Electric Eye Developer Test - Adding "Add To Cart" & "Buy Now" Buttons to Collection Pages

### DIFF
--- a/assets/application.css.liquid
+++ b/assets/application.css.liquid
@@ -1,0 +1,2 @@
+// Put your styles in this file.
+// Note: "@import" rules aren’t supported.

--- a/assets/application.js
+++ b/assets/application.js
@@ -1,0 +1,1 @@
+// Put your application javascript here

--- a/assets/ee_buy_now.js
+++ b/assets/ee_buy_now.js
@@ -1,0 +1,119 @@
+window.onload = function() {
+  let ee_buttons = document.getElementsByClassName("ee-atc-btn");
+
+  for (let i = 0; i < ee_buttons.length; i++) {
+    ee_buttons[i].onclick = function(e) {
+      e.preventDefault();
+      var variantID = this.dataset.variant_id;
+      var clicked = this;
+
+      if (clicked.dataset.redirect === "true") {
+        // Buy Now Should Only Checkout with selected product, regardless of what was already in cart.
+        ee_clearCart().then(() => {
+          ee_buyNow(clicked, variantID);
+        });
+      } else {
+        ee_buyNow(clicked, variantID);
+      }
+    };
+  }
+
+  let ee_dropdowns = document.getElementsByClassName("ee-variant-dropdown");
+
+  for (let i = 0; i < ee_dropdowns.length; i++) {
+    ee_dropdowns[i].onchange = ee_variantSelectChanged;
+  }
+};
+
+function ee_buyNow(clicked, variantID) {
+  var parentDiv = clicked.closest("div");
+  var themeProduct = new window.theme.Product(parentDiv);
+
+  ee_toggleLoading(clicked, true);
+
+  fetch("/cart/add.js", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      items: [{ id: variantID, quantity: 1, form_type: "product" }],
+    }),
+  }).then(function(data) {
+    ee_toggleLoading(clicked, false);
+
+    var response = data.json().then(function(response) {
+      if (data.status === 200) {
+        console.log(response);
+        themeProduct._setupCartPopup(response.items[0]);
+        if (clicked.dataset.redirect === "true") {
+          window.location = "/checkout";
+        }
+      } else {
+        parentDiv.querySelector(
+          "div[data-error-message-wrapper]"
+        ).style.display = "block";
+        parentDiv.querySelector("span[data-error-message]").innerHTML =
+          response.description;
+      }
+    });
+  });
+}
+
+function ee_variantSelectChanged(e) {
+  var self = e.target;
+  var parentDiv = self.closest("div");
+  var currentImg = parentDiv.querySelector(".product-card__image-wrapper img");
+  var currentURL = parentDiv.querySelector("a");
+
+  var selectedOption = self.querySelector("option:checked");
+  var selectedId = selectedOption.dataset.variant_id;
+  var selectedPrice = selectedOption.dataset.variant_price;
+  var selectedImage = selectedOption.dataset.variant_image_url;
+  var selectedURL = selectedOption.dataset.variant_url;
+
+  // Change Add To Cart Button Variant ID
+  parentDiv.querySelector(".ee-atc-btn").dataset.variant_id = selectedId;
+  parentDiv.querySelector(
+    ".price .price__regular dd .price-item"
+  ).innerHTML = selectedPrice;
+
+  // Change Image
+  if (selectedImage != "" && !selectedImage.includes("no-image")) {
+    //Clear Out Old Image
+    currentImg.removeAttribute("srcset");
+    currentImg.removeAttribute("sizes");
+    currentImg.removeAttribute("src");
+    currentImg.dataset.srcset = "";
+    currentImg.dataset.widths = "";
+    currentImg.classList.remove("lazyloaded");
+
+    // Set New Image and Trigger Lazy Load
+    currentImg.dataset.src = selectedImage;
+    currentImg.classList.add("lazyload");
+  }
+
+  // Change Link URL
+  if (selectedURL != "") {
+    currentURL.setAttribute("href", selectedURL);
+  }
+}
+
+function ee_toggleLoading(clicked, disable) {
+  if (disable) {
+    clicked.querySelector("[data-add-to-cart-text]").classList.add("hide");
+    clicked.querySelector("[data-loader]").classList.remove("hide");
+    clicked.setAttribute("disabled", true);
+  } else {
+    clicked.querySelector("[data-add-to-cart-text]").classList.remove("hide");
+    clicked.querySelector("[data-loader]").classList.add("hide");
+    clicked.removeAttribute("disabled");
+  }
+}
+
+function ee_clearCart(cb) {
+  return fetch("/cart/clear.js", {
+    method: "POST",
+    dataType: "text",
+  });
+}

--- a/assets/ee_buy_now.js
+++ b/assets/ee_buy_now.js
@@ -65,37 +65,51 @@ function ee_variantSelectChanged(e) {
   var parentDiv = self.closest("div");
   var currentImg = parentDiv.querySelector(".product-card__image-wrapper img");
   var currentURL = parentDiv.querySelector("a");
+  var currentATCButton = parentDiv.querySelector(".ee-atc-btn");
+  var currentATCButtonLabel = currentATCButton.querySelector("span");
 
   var selectedOption = self.querySelector("option:checked");
   var selectedId = selectedOption.dataset.variant_id;
   var selectedPrice = selectedOption.dataset.variant_price;
   var selectedImage = selectedOption.dataset.variant_image_url;
   var selectedURL = selectedOption.dataset.variant_url;
+  var selectedAvailable = "true" === selectedOption.dataset.variant_available;
 
-  // Change Add To Cart Button Variant ID
-  parentDiv.querySelector(".ee-atc-btn").dataset.variant_id = selectedId;
-  parentDiv.querySelector(
-    ".price .price__regular dd .price-item"
-  ).innerHTML = selectedPrice;
+  if (selectedAvailable) {
+      // Resetting ATC Button if a Out Of Stock Option was selected first.
+    currentATCButtonLabel.innerHTML = currentATCButtonLabel.dataset.og_atc_text;
+    currentATCButton.removeAttribute('disabled');
 
-  // Change Image
-  if (selectedImage != "" && !selectedImage.includes("no-image")) {
-    //Clear Out Old Image
-    currentImg.removeAttribute("srcset");
-    currentImg.removeAttribute("sizes");
-    currentImg.removeAttribute("src");
-    currentImg.dataset.srcset = "";
-    currentImg.dataset.widths = "";
-    currentImg.classList.remove("lazyloaded");
 
-    // Set New Image and Trigger Lazy Load
-    currentImg.dataset.src = selectedImage;
-    currentImg.classList.add("lazyload");
-  }
+    // Change Add To Cart Button Variant ID
+    currentATCButton.dataset.variant_id = selectedId;
+    parentDiv.querySelector(
+      ".price .price__regular dd .price-item"
+    ).innerHTML = selectedPrice;
 
-  // Change Link URL
-  if (selectedURL != "") {
-    currentURL.setAttribute("href", selectedURL);
+    // Change Image
+    if (selectedImage != "" && !selectedImage.includes("no-image")) {
+      //Clear Out Old Image
+      currentImg.removeAttribute("srcset");
+      currentImg.removeAttribute("sizes");
+      currentImg.removeAttribute("src");
+      currentImg.dataset.srcset = "";
+      currentImg.dataset.widths = "";
+      currentImg.classList.remove("lazyloaded");
+
+      // Set New Image and Trigger Lazy Load
+      currentImg.dataset.src = selectedImage;
+      currentImg.classList.add("lazyload");
+    }
+
+    // Change Link URL
+    if (selectedURL != "") {
+      currentURL.setAttribute("href", selectedURL);
+    }
+  } else {
+    // User Somehow Selected an "Out of Stock" Variant
+    currentATCButtonLabel.innerHTML = "Sold Out";
+    currentATCButton.setAttribute('disabled', "true")
   }
 }
 

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1650,6 +1650,15 @@
           "en": "Show Buy Now Button"
         },
         "default": true
+      },
+      {
+        "type": "checkbox",
+        "id": "enable_ee_add_to_cart",
+        "label": {
+
+          "en": "Enable Add To Cart"
+        },
+        "default": true
       }
     ]
   }

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1659,6 +1659,15 @@
           "en": "Enable Add To Cart"
         },
         "default": true
+      },
+      {
+        "type": "checkbox",
+        "id": "enable_ee_select_variants",
+        "label": {
+
+          "en": "Enable Variant Dropdown"
+        },
+        "default": true
       }
     ]
   }

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1635,5 +1635,22 @@
         "default": true
       }
     ]
+  },
+  {
+    "name": {
+
+      "en": "Collection"
+    },
+    "settings": [
+      {
+        "type": "checkbox",
+        "id": "enable_ee_buy_now",
+        "label": {
+
+          "en": "Show Buy Now Button"
+        },
+        "default": true
+      }
+    ]
   }
 ]

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -150,6 +150,7 @@
 
   <script src="{{ 'theme.js' | asset_url }}" defer="defer"></script>
   <script src="{{ 'lazysizes.js' | asset_url }}" async="async"></script>
+  <script src="{{ 'ee_buy_now.js' | asset_url }}" async="async"></script>
 
   <script type="text/javascript">
     if (window.MSInputMethodContext && document.documentMode) {

--- a/snippets/ee_collection-buy-now.liquid
+++ b/snippets/ee_collection-buy-now.liquid
@@ -4,7 +4,7 @@ depending on the settings set in Theme Settings > Collections
 Accepts: -
 product: {Object} Product Liquid object 
 Usage: 
-{% include
+{% render
 'ee_collection-buy-now', product: product %} 
 {% endcomment %} 
 

--- a/snippets/ee_collection-buy-now.liquid
+++ b/snippets/ee_collection-buy-now.liquid
@@ -2,7 +2,7 @@
 Generates a Buy Now Button or Add To Cart Button or nothing,
 depending on the settings set in Theme Settings > Collections 
 Accepts: -
-product: {Object} Product Liquid object (optional) 
+product: {Object} Product Liquid object 
 Usage: 
 {% include
 'ee_collection-buy-now', product: product %} 
@@ -10,192 +10,71 @@ Usage:
 
 {%- if product -%}
     {%- assign variantID = product.variants[0].id -%} 
-{%- endif -%} 
 
-{%- if settings.enable_ee_buy_now == true and settings.enable_ee_add_to_cart != true -%} 
-    {%- assign BuyNow = true -%} 
-{%- elsif settings.enable_ee_buy_now == true and settings.enable_ee_add_to_cart == true -%}
-    {%- assign BuyNow = false -%} 
-{%- endif -%}
+  {%- if settings.enable_ee_buy_now == true and settings.enable_ee_add_to_cart != true -%} 
+      {%- assign BuyNow = true -%} 
+  {%- elsif settings.enable_ee_buy_now == true and settings.enable_ee_add_to_cart == true -%}
+      {%- assign BuyNow = false -%} 
+  {%- endif -%}
 
-{%- assign VariantDropdown = settings.enable_ee_select_variants -%}
+  {%- assign VariantDropdown = settings.enable_ee_select_variants -%}
 
-{% if VariantDropdown and product.variants.size > 1 %}
-    {% assign inStockVariants = product.variants | where: 'available', true %} 
-    {% assign outOfStockVariants = product.variants | where: 'available', false %}
-    {% assign sortedVariants = inStockVariants | concat: outOfStockVariants %} 
-    <select class="ee-variant-dropdown">
-        {%- for variant in sortedVariants -%}
-        <option 
-        data-variant_id="{{variant.id}}"
-        data-variant_price="{{variant.price | money}}"
-        data-variant_image_url="{{variant.image.src | collection_img_url }}"
-        data-variant_available="{{variant.available}}"
-        data-variant_url="{{collection.handle}}{{ variant.url }}"
-        {%- unless variant.available -%}disabled{%- endunless -%}
-        >
-            {{variant.title}} {%- unless variant.available -%}- Out Of Stock{%- endunless -%}
-        </option>
-        {%- endfor -%}
-    </select>
+  {% if VariantDropdown and product.variants.size > 1 %}
+      {% assign inStockVariants = product.variants | where: 'available', true %} 
+      {% assign outOfStockVariants = product.variants | where: 'available', false %}
+      {% assign sortedVariants = inStockVariants | concat: outOfStockVariants %} 
+      <select class="ee-variant-dropdown">
+          {%- for variant in sortedVariants -%}
+          <option 
+          data-variant_id="{{variant.id}}"
+          data-variant_price="{{variant.price | money}}"
+          data-variant_image_url="{{variant.image.src | collection_img_url }}"
+          data-variant_available="{{variant.available}}"
+          data-variant_url="{{collection.handle}}{{ variant.url }}"
+          {%- unless variant.available -%}disabled{%- endunless -%}
+          >
+              {{variant.title}} {%- unless variant.available -%}- Out Of Stock{%- endunless -%}
+          </option>
+          {%- endfor -%}
+      </select>
+
+    {%- endif -%}
+
+  {%- if product.available -%}
+  <button
+    type="button"
+    class="btn ee-atc-btn"
+    data-variant_id="{{ variantID }}"
+    data-redirect={{BuyNow}}
+    data-add-to-cart
+  >
+      <span data-add-to-cart-text>
+
+          {%- if BuyNow == true -%} 
+          Buy Now 
+          {%- else -%}
+          Add To Cart
+          {%- endif -%}
+      </span>
+      <span data-loader class="hide">{%- render 'icon-spinner' -%}</span>
+  </button>
+  <div class="product-form__error-message-wrapper product-form__error-message-wrapper--hidden" data-error-message-wrapper role="alert">
+      <span class="visually-hidden">Error </span>
+      {%- render 'icon-error' -%}
+      <span class="product-form__error-message" data-error-message></span>
+    </div>
+
 
   {%- endif -%}
 
-{%- if product.available -%}
-<button
-  type="button"
-  class="btn ee-atc-btn"
-  data-variant_id="{{ variantID }}"
-  data-redirect={{BuyNow}}
-  data-add-to-cart
->
-    <span data-add-to-cart-text>
 
-        {%- if BuyNow == true -%} 
-        Buy Now 
-        {%- else -%}
-        Add To Cart
-        {%- endif -%}
-    </span>
-    <span data-loader class="hide">{%- render 'icon-spinner' -%}</span>
-</button>
-<div class="product-form__error-message-wrapper product-form__error-message-wrapper--hidden" data-error-message-wrapper role="alert">
-    <span class="visually-hidden">Error </span>
-    {%- render 'icon-error' -%}
-    <span class="product-form__error-message" data-error-message></span>
-  </div>
-
-
+  <style>
+    .ee-atc-btn, .ee-variant-dropdown {
+      display: block;
+      position: relative;
+      z-index: 3;
+      width: 100%;
+      margin-bottom: 1rem;
+    }
+  </style>
 {%- endif -%}
-
-
-<script>
-  window.onload = function() {
-    let ee_buttons = document.getElementsByClassName("ee-atc-btn");
-
-    for (let i = 0; i < ee_buttons.length; i++) {
-      ee_buttons[i].onclick = function(e) {
-        e.preventDefault();
-        var variantID = this.dataset.variant_id;
-        var clicked = this;
-        
-        if (clicked.dataset.redirect === 'true'){
-            // Buy Now Should Only Checkout with selected product, regardless of what was already in cart.
-            clearCart().then(()=>{ buyNow(clicked, variantID)} );
-        } else {
-            buyNow(clicked, variantID);
-        }
-      };
-    }
-
-    let ee_dropdowns = document.getElementsByClassName("ee-variant-dropdown");
-
-    for (let i = 0; i < ee_dropdowns.length; i++) {
-        ee_dropdowns[i].onchange = variantSelectChanged;
-    }
-
-  };
-
-  function buyNow(clicked, variantID) {
-    var parentDiv = clicked.closest('div');
-    var themeProduct = new window.theme.Product(parentDiv);
-
-    toggleLoading(clicked, true);
-
-    fetch("/cart/add.js", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({items: [{  id: variantID, quantity: 1, form_type: 'product'  }] }),
-    }).then(function(data) {
-        toggleLoading(clicked, false);
-
-        var response = data.json().then(function(response) {
-            if (data.status === 200) {
-                console.log(response);
-                themeProduct._setupCartPopup(response.items[0]);
-            if(clicked.dataset.redirect === 'true'){
-                window.location = "/checkout";
-                }
-            } else {
-            parentDiv.querySelector("div[data-error-message-wrapper]").style.display = "block";
-            parentDiv.querySelector("span[data-error-message]").innerHTML = response.description;
-            }
-        });
-    });
-}
-
-function variantSelectChanged(e){
-    var self = e.target
-    var parentDiv = self.closest('div');
-    var currentImg = parentDiv.querySelector('.product-card__image-wrapper img');
-    var currentURL = parentDiv.querySelector('a');
-
-    var selectedOption = self.querySelector('option:checked');
-    var selectedId = selectedOption.dataset.variant_id;
-    var selectedPrice = selectedOption.dataset.variant_price;
-    var selectedImage = selectedOption.dataset.variant_image_url;
-    var selectedURL = selectedOption.dataset.variant_url
-
-    // Change Add To Cart Button Variant ID
-    parentDiv.querySelector('.ee-atc-btn').dataset.variant_id = selectedId;
-    parentDiv.querySelector('.price .price__regular dd .price-item').innerHTML = selectedPrice;
-
-    // Change Image
-    if(selectedImage != "" && !selectedImage.includes('no-image')){
-
-      currentImg.removeAttribute('srcset');
-      currentImg.removeAttribute('sizes');
-      currentImg.removeAttribute('src');
-      currentImg.dataset.srcset = '';
-      currentImg.dataset.widths = '';
-      currentImg.classList.remove('lazyloaded');
-      
-      
-      currentImg.dataset.src = selectedImage;
-      currentImg.classList.add('lazyload');
-    }
-
-    // Change Link URL
-    if(selectedURL != ''){
-      currentURL.setAttribute('href', selectedURL);
-    }
-}
-
-
-  function toggleLoading(clicked, disable){
-
-    if(disable){
-        clicked.querySelector("[data-add-to-cart-text]").classList.add("hide");
-        clicked.querySelector("[data-loader]").classList.remove("hide");
-        clicked.setAttribute("disabled", true);
-    } else {
-        clicked.querySelector("[data-add-to-cart-text]").classList.remove("hide");
-        clicked.querySelector("[data-loader]").classList.add("hide");
-        clicked.removeAttribute("disabled");
-    }
-
-  }
-
-  function clearCart(cb){
-
-    return fetch("/cart/clear.js", 
-    {
-        method: "POST",
-        dataType: "text",
-    }
-);
-
-}
-</script>
-
-<style>
-  .ee-atc-btn, .ee-variant-dropdown {
-    display: block;
-    position: relative;
-    z-index: 3;
-    width: 100%;
-    margin-bottom: 1rem;
-  }
-</style>

--- a/snippets/ee_collection-buy-now.liquid
+++ b/snippets/ee_collection-buy-now.liquid
@@ -191,19 +191,11 @@ function variantSelectChanged(e){
 </script>
 
 <style>
-  .ee-atc-btn {
+  .ee-atc-btn, .ee-variant-dropdown {
     display: block;
     position: relative;
     z-index: 3;
     width: 100%;
     margin-bottom: 1rem;
-  }
-
-
-  .ee-variant-dropdown{
-      width: 100%;
-      display: block;
-      position: relative;
-      z-index:3;
   }
 </style>

--- a/snippets/ee_collection-buy-now.liquid
+++ b/snippets/ee_collection-buy-now.liquid
@@ -48,13 +48,17 @@ Usage:
     data-redirect={{BuyNow}}
     data-add-to-cart
   >
-      <span data-add-to-cart-text>
 
-          {%- if BuyNow == true -%} 
-          Buy Now 
-          {%- else -%}
-          Add To Cart
-          {%- endif -%}
+  {%- capture atc_text -%}
+    {%- if BuyNow == true -%} 
+    Buy Now 
+    {%- else -%}
+    Add To Cart
+    {%- endif -%}
+  {%- endcapture -%}
+
+      <span data-add-to-cart-text data-og_atc_text="{{atc_text}}">
+        {{atc_text}}
       </span>
       <span data-loader class="hide">{%- render 'icon-spinner' -%}</span>
   </button>

--- a/snippets/ee_collection-buy-now.liquid
+++ b/snippets/ee_collection-buy-now.liquid
@@ -1,0 +1,86 @@
+{% comment %} 
+Generates a Buy Now Button or Add To Cart Button or nothing,
+depending on the settings set in Theme Settings > Collections 
+Accepts: -
+product: {Object} Product Liquid object (optional) 
+Usage: 
+{% include
+'ee_collection-buy-now', product: product %} 
+{% endcomment %} 
+
+{%- if product -%}
+{%- assign variantID = product.variants[0].id -%} {%- endif -%} {%- if
+settings.enable_ee_buy_now -%} {%- if product.available -%}
+<button
+  onclick="buyNow(e)"
+  type="button"
+  class="btn ee-BuyNow"
+  data-variant_id="{{ variantID }}"
+>
+  Buy Now
+</button>
+
+{%- endif -%} {%- endif -%}
+
+<script>
+  window.onload = function() {
+    let elements = document.getElementsByClassName("ee-BuyNow");
+
+    for (let i = 0; i < elements.length; i++) {
+      elements[i].onclick = function(e) {
+        e.preventDefault();
+        var variantID = this.dataset.variant_id;
+
+        buyNow(this, variantID);
+      };
+    }
+  };
+
+  function buyNow(clicked, variantID) {
+    var OriginalInnerHTML = clicked.innerHTML;
+    clicked.classList.remove("error");
+    clicked.classList.add("loading");
+    clicked.setAttribute("disabled", true);
+    clicked.innerHTML = "Adding...";
+
+    fetch("/cart/add.js", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ items: [{ quantity: 1, id: variantID }] }),
+    }).then(function(data) {
+      clicked.setAttribute("disabled", false);
+
+      console.log(data);
+      var response = data.json().then(function(response) {
+        if (data.status == 200) {
+          clicked.classList.remove("loading");
+          clicked.innerHTML = OriginalInnerHTML;
+          window.location = "/checkout";
+        } else {
+          clicked.classList.add("error");
+          clicked.innerHTML = response.message;
+        }
+      });
+    });
+  }
+</script>
+
+<style>
+  .ee-BuyNow {
+    display: block;
+    position: relative;
+    z-index: 3;
+    width: 100%;
+    margin-bottom: 1rem;
+  }
+
+  .ee-BuyNow.loading {
+    background: #333;
+  }
+
+  .ee-BuyNow.error {
+    background: red;
+  }
+</style>

--- a/snippets/ee_collection-buy-now.liquid
+++ b/snippets/ee_collection-buy-now.liquid
@@ -9,78 +9,128 @@ Usage:
 {% endcomment %} 
 
 {%- if product -%}
-{%- assign variantID = product.variants[0].id -%} {%- endif -%} {%- if
-settings.enable_ee_buy_now -%} {%- if product.available -%}
-<button
-  onclick="buyNow(e)"
-  type="button"
-  class="btn ee-BuyNow"
-  data-variant_id="{{ variantID }}"
->
-  Buy Now
-</button>
+    {%- assign variantID = product.variants[0].id -%} 
+{%- endif -%} 
 
-{%- endif -%} {%- endif -%}
+{%- if settings.enable_ee_buy_now == true and settings.enable_ee_add_to_cart != true -%} 
+    {%- assign BuyNow = true -%} 
+{%- elsif settings.enable_ee_buy_now == true and settings.enable_ee_add_to_cart == true -%}
+    {%- assign BuyNow = false -%} 
+{%- endif -%}
+
+
+{%- if product.available -%}
+<button
+  type="button"
+  class="btn ee-atc-btn"
+  data-variant_id="{{ variantID }}"
+  data-redirect={{BuyNow}}
+  data-add-to-cart
+>
+<span data-add-to-cart-text>
+
+    {%- if BuyNow == true -%} 
+    Buy Now 
+    {%- else -%}
+    Add To Cart
+    {%- endif -%}
+</span>
+<span data-loader class="hide">{%- render 'icon-spinner' -%}</span>
+</button>
+<div class="product-form__error-message-wrapper product-form__error-message-wrapper--hidden" data-error-message-wrapper role="alert">
+    <span class="visually-hidden">Error </span>
+    {%- render 'icon-error' -%}
+    <span class="product-form__error-message" data-error-message></span>
+  </div>
+
+
+{%- endif -%}
+
 
 <script>
   window.onload = function() {
-    let elements = document.getElementsByClassName("ee-BuyNow");
+    let ee_buttons = document.getElementsByClassName("ee-atc-btn");
 
-    for (let i = 0; i < elements.length; i++) {
-      elements[i].onclick = function(e) {
+    for (let i = 0; i < ee_buttons.length; i++) {
+      ee_buttons[i].onclick = function(e) {
         e.preventDefault();
         var variantID = this.dataset.variant_id;
-
-        buyNow(this, variantID);
+        var clicked = this;
+        
+        if (clicked.dataset.redirect === 'true'){
+            // Buy Now Should Only Checkout with selected product, regardless of what was already in cart.
+            clearCart().then(()=>{ buyNow(clicked, variantID)} );
+        } else {
+            buyNow(clicked, variantID);
+        }
       };
     }
+
   };
 
   function buyNow(clicked, variantID) {
-    var OriginalInnerHTML = clicked.innerHTML;
-    clicked.classList.remove("error");
-    clicked.classList.add("loading");
-    clicked.setAttribute("disabled", true);
-    clicked.innerHTML = "Adding...";
+    var parentDiv = clicked.closest('div');
+    var themeProduct = new window.theme.Product(parentDiv);
+
+    toggleLoading(clicked, true);
 
     fetch("/cart/add.js", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ items: [{ quantity: 1, id: variantID }] }),
+      body: JSON.stringify({items: [{  id: variantID, quantity: 1, form_type: 'product'  }] }),
     }).then(function(data) {
-      clicked.setAttribute("disabled", false);
+        toggleLoading(clicked, false);
 
-      console.log(data);
-      var response = data.json().then(function(response) {
-        if (data.status == 200) {
-          clicked.classList.remove("loading");
-          clicked.innerHTML = OriginalInnerHTML;
-          window.location = "/checkout";
-        } else {
-          clicked.classList.add("error");
-          clicked.innerHTML = response.message;
-        }
-      });
+        var response = data.json().then(function(response) {
+            if (data.status === 200) {
+                console.log(response);
+                themeProduct._setupCartPopup(response.items[0]);
+            if(clicked.dataset.redirect === 'true'){
+                window.location = "/checkout";
+                }
+            } else {
+            parentDiv.querySelector("div[data-error-message-wrapper]").style.display = "block";
+            parentDiv.querySelector("span[data-error-message]").innerHTML = response.description;
+            }
+        });
     });
+}
+
+
+  function toggleLoading(clicked, disable){
+
+    if(disable){
+        clicked.querySelector("[data-add-to-cart-text]").classList.add("hide");
+        clicked.querySelector("[data-loader]").classList.remove("hide");
+        clicked.setAttribute("disabled", true);
+    } else {
+        clicked.querySelector("[data-add-to-cart-text]").classList.remove("hide");
+        clicked.querySelector("[data-loader]").classList.add("hide");
+        clicked.removeAttribute("disabled");
+    }
+
   }
+
+  function clearCart(cb){
+
+    return fetch("/cart/clear.js", 
+    {
+        method: "POST",
+        dataType: "text",
+    }
+);
+
+}
 </script>
 
 <style>
-  .ee-BuyNow {
+  .ee-atc-btn {
     display: block;
     position: relative;
     z-index: 3;
     width: 100%;
     margin-bottom: 1rem;
-  }
-
-  .ee-BuyNow.loading {
-    background: #333;
-  }
-
-  .ee-BuyNow.error {
-    background: red;
   }
 </style>

--- a/snippets/ee_collection-buy-now.liquid
+++ b/snippets/ee_collection-buy-now.liquid
@@ -18,6 +18,28 @@ Usage:
     {%- assign BuyNow = false -%} 
 {%- endif -%}
 
+{%- assign VariantDropdown = settings.enable_ee_select_variants -%}
+
+{% if VariantDropdown and product.variants.size > 1 %}
+    {% assign inStockVariants = product.variants | where: 'available', true %} 
+    {% assign outOfStockVariants = product.variants | where: 'available', false %}
+    {% assign sortedVariants = inStockVariants | concat: outOfStockVariants %} 
+    <select class="ee-variant-dropdown">
+        {%- for variant in sortedVariants -%}
+        <option 
+        data-variant_id="{{variant.id}}"
+        data-variant_price="{{variant.price | money}}"
+        data-variant_image_url="{{variant.image.src | collection_img_url }}"
+        data-variant_available="{{variant.available}}"
+        data-variant_url="{{collection.handle}}{{ variant.url }}"
+        {%- unless variant.available -%}disabled{%- endunless -%}
+        >
+            {{variant.title}} {%- unless variant.available -%}- Out Of Stock{%- endunless -%}
+        </option>
+        {%- endfor -%}
+    </select>
+
+  {%- endif -%}
 
 {%- if product.available -%}
 <button
@@ -27,15 +49,15 @@ Usage:
   data-redirect={{BuyNow}}
   data-add-to-cart
 >
-<span data-add-to-cart-text>
+    <span data-add-to-cart-text>
 
-    {%- if BuyNow == true -%} 
-    Buy Now 
-    {%- else -%}
-    Add To Cart
-    {%- endif -%}
-</span>
-<span data-loader class="hide">{%- render 'icon-spinner' -%}</span>
+        {%- if BuyNow == true -%} 
+        Buy Now 
+        {%- else -%}
+        Add To Cart
+        {%- endif -%}
+    </span>
+    <span data-loader class="hide">{%- render 'icon-spinner' -%}</span>
 </button>
 <div class="product-form__error-message-wrapper product-form__error-message-wrapper--hidden" data-error-message-wrapper role="alert">
     <span class="visually-hidden">Error </span>
@@ -64,6 +86,12 @@ Usage:
             buyNow(clicked, variantID);
         }
       };
+    }
+
+    let ee_dropdowns = document.getElementsByClassName("ee-variant-dropdown");
+
+    for (let i = 0; i < ee_dropdowns.length; i++) {
+        ee_dropdowns[i].onchange = variantSelectChanged;
     }
 
   };
@@ -96,6 +124,43 @@ Usage:
             }
         });
     });
+}
+
+function variantSelectChanged(e){
+    var self = e.target
+    var parentDiv = self.closest('div');
+    var currentImg = parentDiv.querySelector('.product-card__image-wrapper img');
+    var currentURL = parentDiv.querySelector('a');
+
+    var selectedOption = self.querySelector('option:checked');
+    var selectedId = selectedOption.dataset.variant_id;
+    var selectedPrice = selectedOption.dataset.variant_price;
+    var selectedImage = selectedOption.dataset.variant_image_url;
+    var selectedURL = selectedOption.dataset.variant_url
+
+    // Change Add To Cart Button Variant ID
+    parentDiv.querySelector('.ee-atc-btn').dataset.variant_id = selectedId;
+    parentDiv.querySelector('.price .price__regular dd .price-item').innerHTML = selectedPrice;
+
+    // Change Image
+    if(selectedImage != "" && !selectedImage.includes('no-image')){
+
+      currentImg.removeAttribute('srcset');
+      currentImg.removeAttribute('sizes');
+      currentImg.removeAttribute('src');
+      currentImg.dataset.srcset = '';
+      currentImg.dataset.widths = '';
+      currentImg.classList.remove('lazyloaded');
+      
+      
+      currentImg.dataset.src = selectedImage;
+      currentImg.classList.add('lazyload');
+    }
+
+    // Change Link URL
+    if(selectedURL != ''){
+      currentURL.setAttribute('href', selectedURL);
+    }
 }
 
 
@@ -132,5 +197,13 @@ Usage:
     z-index: 3;
     width: 100%;
     margin-bottom: 1rem;
+  }
+
+
+  .ee-variant-dropdown{
+      width: 100%;
+      display: block;
+      position: relative;
+      z-index:3;
   }
 </style>

--- a/snippets/product-card-grid.liquid
+++ b/snippets/product-card-grid.liquid
@@ -47,5 +47,5 @@
   {% include 'product-price-listing', product: product, show_vendor: show_vendor %}
 
   
-  {% include 'ee_collection-buy-now', product: product %}
+  {% render 'ee_collection-buy-now', product: product %}
 </div>

--- a/snippets/product-card-grid.liquid
+++ b/snippets/product-card-grid.liquid
@@ -46,4 +46,6 @@
 
   {% include 'product-price-listing', product: product, show_vendor: show_vendor %}
 
+  
+  {% include 'ee_collection-buy-now', product: product %}
 </div>

--- a/snippets/product-card-list.liquid
+++ b/snippets/product-card-list.liquid
@@ -34,7 +34,7 @@
     <div class="list-view-item__price-column">
       {% include 'product-price-listing', product: product, show_vendor: false %}
     </div>
-  {% include 'ee_collection-buy-now', product: product %}
+  {% render 'ee_collection-buy-now', product: product %}
 
   </div>
 </div>

--- a/snippets/product-card-list.liquid
+++ b/snippets/product-card-list.liquid
@@ -34,5 +34,7 @@
     <div class="list-view-item__price-column">
       {% include 'product-price-listing', product: product, show_vendor: false %}
     </div>
+  {% include 'ee_collection-buy-now', product: product %}
+
   </div>
 </div>

--- a/templates/collection.list.liquid
+++ b/templates/collection.list.liquid
@@ -1,0 +1,17 @@
+{% paginate collection.products by 2 %}
+  <h1>{{ collection.title }}</h1>
+  {% for product in collection.products %}
+    <div>
+      <a href="{{ product.url | within: collection }}">{{ product.title }}</a>
+      {{ product.price | money }}
+      {% unless product.available %}<br><strong>sold out</strong>{% endunless %}
+      <a href="{{ product.url | within: collection }}">
+        <img src="{{ product.featured_image.src | img_url: 'large' }}" alt="{{ product.featured_image.alt | escape }}">
+      </a>
+    </div>
+  {% else %}
+    <p>no matches</p>
+  {% endfor %}
+  {% if paginate.pages > 1 %}{{ paginate | default_pagination }}{% endif %}
+{% endpaginate %}
+


### PR DESCRIPTION
## Phase 1a Requirements:

- [x]  Create a new "Collection" section in the Shopify theme customize view, under "Theme settings"

- [x]  This new setting section contains a toggle for enabling our new buy now feature

- [x] On collection pages, a "buy now" button shows under each available product when the toggle is 
    - [x] Do not show if the product is unavailable

- [x] When buy now is clicked, the browser is redirected to checkout with the chosen product in the cart

## Phase 1b Requirements: 


- [x] Create a second toggle to change the button to "add to cart"

- [x] The "buy now" button under each product changes to an "add to cart" button when both toggles are on

- [x] When add to cart is clicked, the product is added to the cart, and the browser does not redirect

- [x] Ideally, the existing functionality for adding to cart on a PDP is replicated

    - [x] Cart size counter in the header updates

    - [x] A small modal displays with information about the newly added product

    - [x] Bonus points for handling the error the same way as well

## Phase 2 Requirements

- [x] Create a third toggle to show or hide product variants

- [x] If a product has multiple variants, a select dropdown displays
    - Each of the product's variants display as options
    - Disable variants that are unavailable
 

- [x] When a different variant is selected, the data in the product listing changes
    - Image
    - Price
    - Product Link (Append Variant to URL)

- [x] Bonus Points:
    - [x] Always have an in-stock variant selected by default
    - [x] Handle errors
        - [x] Match functionality on PDPs
